### PR TITLE
Make remove use {safe: true}

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -158,7 +158,7 @@ Loader.prototype.clear = function(collectionNames, cb) {
                 results.db.collection(name, function(err, collection) {
                     if (err) return cb(err);
 
-                    collection.remove({}, cb);
+                    collection.remove({}, {safe: true} cb);
                 });
             }, cb);
         }


### PR DESCRIPTION
If it isn't safe, it could cause a database error when data with a unique index is inserted before it was fully removed.
