### PR TITLE
Let mongofixtures accept absolute paths to the fixture

### DIFF
--- a/bin/mongofixtures
+++ b/bin/mongofixtures
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
-var argv = require('optimist').argv;
+var argv = require('optimist').argv,
+    path = require('path');
 
 var dbName = argv._[0],
-    file = process.cwd() + '/' + argv._[1];
+    file = path.resolve(process.cwd(), argv._[1]);
 
 var fixtures = require('pow-mongodb-fixtures').connect(dbName);
 


### PR DESCRIPTION
Currently it will only accept relative paths, and will try to append a given absolute path to the cwd. This pull request will allow it to handle both.

Before:

``` bash
mongofixtures db foo.js
# --> /Users/evdb/git/pow-mongodb-fixtures/foo.js
mongofixtures db /tmp/foo.js
# --> /Users/evdb/git/pow-mongodb-fixtures//tmp/foo.js
```

After:

``` bash
mongofixtures db foo.js
# --> /Users/evdb/git/pow-mongodb-fixtures/foo.js
mongofixtures db /tmp/foo.js
# --> /tmp/foo.js
```
