### PR TITLE
Locked mongodb to ~1.3.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 /node_modules/
-
+.npmrc

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
 		"async": "0.1.15",
-		"mongodb": ">=1.3.0",
+		"mongodb": "~1.3.20",
 		"underscore": ">=1.2.2",
 		"bson": ">=0.0.4",
     "optimist": "0.3.5"


### PR DESCRIPTION
clearAndLoad uses functionality that changes in mongodb 2.x, lock to 1.3.x so that things continue to work as expected.