### PR TITLE
Upgrade mongodb drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ Installation
 Changelog
 ---------
 
+###0.12.0  
+- Update mongodb driver to 2.0.x  
+- Updated `collection.insert` with `collection.insertMany` - the former is marked for deprecation in version 3.x  
+- Move to Lo-Dash from Underscore  
+- Refactor `clear` to be the point - drop the db if no collection name passed in, otherwise drop specified collection    
+
 ###0.10.0
 - Update mongodb driver to 1.3.x
 - Add ability to connect with URI

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Charles Davison <charlie@powmedia.co.uk>",
   "name": "pow-mongodb-fixtures",
   "description": "Easy JSON fixture loading for MongoDB.  Makes managing document relationships easier.",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "repository": {
     "type": "git",
     "url": "http://github.com/powmedia/pow-mongodb-fixtures.git"
@@ -16,10 +16,10 @@
   "dependencies": {
     "async": "0.1.15",
     "bson": ">=0.0.4",
-    "mongodb": "~1.3.20",
+    "mongodb": "~2.0.36",
     "nodeunit": "^0.9.1",
     "optimist": "0.3.5",
-    "underscore": ">=1.2.2"
+    "lodash": "~3.10.0"
   },
   "devDependencies": {
     "nodeunit": "0.6.4"

--- a/src/index.js
+++ b/src/index.js
@@ -346,7 +346,7 @@ var _loadData = function(loader, data, cb) {
         db.collection(collectionName, function(err, collection) {
           if (err) return cbForEachCollection(err);
 
-          collection.insert(modifiedItems, { safe: true }, cbForEachCollection);
+          collection.insertMany(modifiedItems, { safe: true }, cbForEachCollection);
         });
       });
 		}, cb);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -455,7 +455,7 @@ exports['clear'] = {
         ], test.done);
     },
     
-    'clearing non-existent collections shouldnt error': function(test) {
+    'clearing non-existent collections shouldn\'t error': function(test) {
         loader.clear('fheruas', function(err) {
             test.ifError(err);
             


### PR DESCRIPTION
**Refactor clear method to be on par with description**
*REFACTORED:*
- If the provided collection does not exist or no collection is passed in, drop the database directly. Otherwise, remove the specified collections.
- Clean up the code for getCollectionNames() and clearCollections() functions to carry out operation specified above  

**Update insert to insertMany in _loadData method**
*UPDATED:*
- Updated insert to insertMany since insert is deprecated in this version of the driver  

**Change wording in test**
*UPDATED:*
- Update the wording for one of the test cases  

**Updated README**
*UPDATED:*
- Updated README to reflect changes made in this version  

**Update package.json**
*UPDATED:*
- Updated to latest mongodb driver for Node
- Upgraded to lodash from underscore
- Updated version