### PR TITLE
Section under API about closing the connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,22 @@ Usage:
       port: 1234
     });
 
+connect(callback)
+-----------------
+
+Close the connection to the DB
+
+Usage:
+
+    // Connect!
+    var fixtures = require('pow-mongodb-fixtures').connect('dbname');
+    
+    // Load some fixtures
+    fixtures.load(__dirname + '/fixtures/users.js', function(err) {
+        // Don't forget to close!
+    	fixtures.close(function(err) { ... });
+    });
+    
 
 load(data, callback)
 --------------------


### PR DESCRIPTION
This personally tripped me up. I couldn't figure out why my jasmine specs we're not exiting properly. I did a little source dive and found the close method's implementation. I think it makes a fine addition to the README.
