### PR TITLE
Switches from drop to removeMany

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -74,7 +74,7 @@ var Loader = exports.Loader = function(dbOrUri, options) {
       safe: true
     }, options);
   }
-  
+
   this.options = options;
   this.modifiers = [];
 };
@@ -192,7 +192,7 @@ Loader.prototype.clear = function(collectionNames, cb) {
         async.forEach(results.collectionNames, function(name, cb) {
           var collection = results.db.collection(name);
 
-          collection.drop(cb);
+          collection.removeMany({}, cb);
         }, cb);
       } else { cb(); }
     }


### PR DESCRIPTION
It seems like many people (myself included) were receiving sporadic errors about mongodb background operations. This is because the drop command also clears indices for the collection, forcing mongodb to reindex the next time the collection is used. Switching the command from drop to removeMany keeps the indices intact and prevents this from happening.