### PR TITLE
Lock BSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "async": "0.1.15",
-    "bson": ">=0.0.4",
+    "bson": ">=0.0.4 <=0.4.23",
     "mongodb": "~2.0.36",
     "nodeunit": "^0.9.1",
     "optimist": "0.3.5",


### PR DESCRIPTION
Looks like `0.5.0` has introduced some breakages, so I figured we could lock this down for a time being? 
