### PR TITLE
Change collection.drop() to collection.deleteMany()

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ Loader.prototype.clear = function(collectionNames, cb) {
         async.forEach(results.collectionNames, function(name, cb) {
           var collection = results.db.collection(name);
 
-          collection.drop(cb);
+          collection.deleteMany({}, cb);
         }, cb);
       } else { cb(); }
     }


### PR DESCRIPTION
The `collection.drop()` method completely erases a collection from the database, including its indexes. It's better to only remove the documents but keep the indexes, since the user might use them in their tests. The method in mongodb-native v2.0 that allows just that is [`collection.deleteMany()`](http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html#deleteMany). This is a correction of PR #31, since there is no `removeMany()` method on the [collection API](http://mongodb.github.io/node-mongodb-native/2.0/api/Collection.html)