### PR TITLE
Switch to mongo client to support mongo 3.x

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -284,7 +284,7 @@ var _connect = function(loader, cb) {
   MongoClient.connect(options.uri, function(err, client) {
     if (err) return cb(err);
 
-    let db = client.db(options.db);
+    var db = client.db(options.db);
     loader.client = db;
 
     cb(null, db);


### PR DESCRIPTION
When i try to use a mongo version 3.6 with auth to run the fixtures, and error comes out, so i just switch to *MongoClient* to connect followed mongodb instructions

``` javascript
Db.prototype.authenticate method will no longer be available in the next major release 3.x as MongoDB 3.6 will only allow auth against users in the admin db and will no longer allow multiple credentials on a socket. 
Please authenticate using MongoClient.connect with auth credentials.
{ MongoError: Authentication failed.
    at Function.MongoError.create (~/xxx/node_modules/mongodb-core/lib/error.js:31:11)
    at ~/xxx/node_modules/mongodb-core/lib/connection/pool.js:497:72
    at authenticateStragglers (~/xxx/node_modules/mongodb-core/lib/connection/pool.js:443:16)
    at Connection.messageHandler (~/xxx/node_modules/mongodb-core/lib/connection/pool.js:477:5)
    at Socket.<anonymous> (~/xxx/node_modules/mongodb-core/lib/connection/connection.js:333:22)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)
    at readableAddChunk (_stream_readable.js:250:11)
    at Socket.Readable.push (_stream_readable.js:208:10)
  name: 'MongoError',
  message: 'Authentication failed.',
  ok: 0,
  errmsg: 'Authentication failed.',
  code: 18,
  codeName: 'AuthenticationFailed' }
```